### PR TITLE
fix(ci): update node version for github actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 19
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/paragraph",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "keywords": [
     "codex editor",
     "paragraph",


### PR DESCRIPTION
This PR fixes GitHub Actions:

<img width="1152" alt="image" src="https://github.com/editor-js/paragraph/assets/3684889/6971c0c7-3a57-48d0-96c8-fa4e0541689c">
