### PR TITLE
fix(jsdelivr): explicitly specify a bundle for jsdelivr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/paragraph",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "keywords": [
     "codex editor",
     "paragraph",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "require": "./dist/paragraph.umd.cjs"
     }
   },
+  "jsdelivr": "./dist/paragraph.js",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
JsDelivr loads the `paragraph.umg.cjs` (which is marked as "main") by the `@latest` flag. It incorrectly treat it as node.js module giving wrong mime-type.

For now such link does not work:
```
https://cdn.jsdelivr.net/npm/@editorjs/paragraph@latest
```

It does work:
```
https://cdn.jsdelivr.net/npm/@editorjs/paragraph@latest/+esm
```

After this PR, the `@latest` tag should work (probably). Can't test it locally.

Resolves #77