### PR TITLE
Enable useStrictCSP for cssInjectedByJsPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ The Paragraph Tool supports these configuration parameters:
 }
 ```
 
+## CSP support
+
+If you're using Content Security Policy (CSP) pass a `nonce` via [`<meta property="csp-nonce" content={{ nonce }} />`](https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean) in your document head.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/paragraph",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "keywords": [
     "codex editor",
     "paragraph",

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,6 @@ export default {
   },
 
   plugins: [
-    cssInjectedByJsPlugin(),
+    cssInjectedByJsPlugin({useStrictCSP: true}),
   ],
 };


### PR DESCRIPTION
Enables useStrictCSP when injecting styles. See https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean

Does not throw any errors if meta property is not present

```useStrictCSP ? `elementStyle.nonce = document.head.querySelector('meta[property=csp-nonce]')?.content;` : ''```

Updated README to reflect the out of the box support