### PR TITLE
export types .d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "exports": {
     ".": {
       "import": "./dist/paragraph.mjs",
-      "require": "./dist/paragraph.umd.js"
+      "require": "./dist/paragraph.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
```
import Paragraph from '@editorjs/paragraph'
```

could not find types since types were not exported. (typo? in package.json)